### PR TITLE
Use 2-3 trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@
 ### Types
 
     data Edge k where
+      Edge :: k -> k -> Edge k
 
     data Graph k v where
+      Graph :: [v] -> [Edge k] -> Graph k v
 
     data SCC v where
+      AcyclicSCC :: v -> SCC v
+      CyclicSCC :: [v] -> SCC v
 
 
 ### Type Class Instances
@@ -35,12 +39,14 @@
 
 ### Types
 
-    data Map k v where
+    data Map k v
 
 
 ### Type Class Instances
 
     instance eqMap :: (P.Eq k, P.Eq v) => P.Eq (Map k v)
+
+    instance functorMap :: P.Functor (Map k)
 
     instance showMap :: (P.Show k, P.Show v) => P.Show (Map k v)
 
@@ -48,6 +54,8 @@
 ### Values
 
     alter :: forall k v. (P.Ord k) => (Maybe v -> Maybe v) -> k -> Map k v -> Map k v
+
+    checkValid :: forall k v. Map k v -> Boolean
 
     delete :: forall k v. (P.Ord k) => k -> Map k v -> Map k v
 
@@ -57,13 +65,17 @@
 
     insert :: forall k v. (P.Ord k) => k -> v -> Map k v -> Map k v
 
+    isEmpty :: forall k v. Map k v -> Boolean
+
     keys :: forall k v. Map k v -> [k]
 
     lookup :: forall k v. (P.Ord k) => k -> Map k v -> Maybe v
 
-    map :: forall k v1 v2. (P.Ord k) => (v1 -> v2) -> Map k v1 -> Map k v2
+    map :: forall k a b. (a -> b) -> Map k a -> Map k b
 
-    member :: forall k v. (P.Ord k) => k -> Map k v -> Prim.Boolean
+    member :: forall k v. (P.Ord k) => k -> Map k v -> Boolean
+
+    showTree :: forall k v. (P.Show k, P.Show v) => Map k v -> String
 
     singleton :: forall k v. k -> v -> Map k v
 
@@ -82,7 +94,7 @@
 
 ### Types
 
-    data Set a where
+    data Set a
 
 
 ### Type Class Instances
@@ -94,20 +106,24 @@
 
 ### Values
 
-    delete :: forall a. (P.Eq a, P.Ord a) => a -> Set a -> Set a
+    checkValid :: forall a. Set a -> Boolean
+
+    delete :: forall a. (P.Ord a) => a -> Set a -> Set a
 
     empty :: forall a. Set a
 
-    fromList :: forall a. (P.Eq a, P.Ord a) => [a] -> Set a
+    fromList :: forall a. (P.Ord a) => [a] -> Set a
 
-    insert :: forall a. (P.Eq a, P.Ord a) => a -> Set a -> Set a
+    insert :: forall a. (P.Ord a) => a -> Set a -> Set a
 
-    member :: forall a. (P.Eq a, P.Ord a) => a -> Set a -> Prim.Boolean
+    isEmpty :: forall a. Set a -> Boolean
+
+    member :: forall a. (P.Ord a) => a -> Set a -> Boolean
 
     singleton :: forall a. a -> Set a
 
     toList :: forall a. Set a -> [a]
 
-    union :: forall a. (P.Eq a, P.Ord a) => Set a -> Set a -> Set a
+    union :: forall a. (P.Ord a) => Set a -> Set a -> Set a
 
     unions :: forall a. (P.Ord a) => [Set a] -> Set a

--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -1,105 +1,222 @@
-module Data.Map
+--
+-- Maps as balanced 2-3 trees
+--
+-- Based on http://www.cs.princeton.edu/~dpw/courses/cos326-12/ass/2-3-trees.pdf
+--
+
+module Data.Map 
   ( Map(),
+    showTree,
     empty,
+    isEmpty,
     singleton,
+    checkValid,
     insert,
     lookup,
-    member,
-    delete,
-    alter,
-    update,
     toList,
     fromList,
+    delete,
+    member,
+    alter,
+    update,
     keys,
     values,
     union,
     unions,
     map
   ) where
-
+  
 import qualified Prelude as P
 
-import Data.Array (concat)
-import Data.Foldable (foldl)
-import Data.Maybe
+import qualified Data.Array as A
+import Data.Maybe 
 import Data.Tuple
-
-data Map k v = Leaf | Branch { key :: k, value :: v, left :: Map k v, right :: Map k v }
+import Data.Foldable (foldl) 
+  
+data Map k v 
+  = Leaf
+  | Two (Map k v) k v (Map k v)
+  | Three (Map k v) k v (Map k v) k v (Map k v)
 
 instance eqMap :: (P.Eq k, P.Eq v) => P.Eq (Map k v) where
   (==) m1 m2 = toList m1 P.== toList m2
   (/=) m1 m2 = P.not (m1 P.== m2)
 
 instance showMap :: (P.Show k, P.Show v) => P.Show (Map k v) where
-  show m = "fromList " P.++ P.show (toList m)
+  show m = "fromList " P.++ P.show (toList m) 
 
+instance functorMap :: P.Functor (Map k) where
+  (<$>) _ Leaf = Leaf
+  (<$>) f (Two left k v right) = Two (f P.<$> left) k (f v) (f P.<$> right)
+  (<$>) f (Three left k1 v1 mid k2 v2 right) = Three (f P.<$> left) k1 (f v1) (f P.<$> mid) k2 (f v2) (f P.<$> right)
+  
+showTree :: forall k v. (P.Show k, P.Show v) => Map k v -> String  
+showTree Leaf = "Leaf"
+showTree (Two left k v right) = 
+  "Two (" P.++ showTree left P.++ 
+  ") (" P.++ P.show k P.++ 
+  ") (" P.++ P.show v P.++ 
+  ") (" P.++ showTree right P.++ ")"
+showTree (Three left k1 v1 mid k2 v2 right) = 
+  "Three (" P.++ showTree left P.++ 
+  ") (" P.++ P.show k1 P.++ 
+  ") (" P.++ P.show v1 P.++ 
+  ") (" P.++ showTree mid P.++
+  ") (" P.++ P.show k2 P.++ 
+  ") (" P.++ P.show v2 P.++ 
+  ") (" P.++ showTree right P.++ ")"
+  
 empty :: forall k v. Map k v
 empty = Leaf
 
+isEmpty :: forall k v. Map k v -> Boolean
+isEmpty Leaf = true
+isEmpty _ = false
+
 singleton :: forall k v. k -> v -> Map k v
-singleton k v = Branch { key: k, value: v, left: empty, right: empty }
-
-insert :: forall k v. (P.Ord k) => k -> v -> Map k v -> Map k v
-insert k v Leaf = singleton k v
-insert k v (Branch b@{ key = k1 }) | k P.== k1 = Branch (b { key = k, value = v })
-insert k v (Branch b@{ key = k1 }) | k P.< k1 = Branch (b { left = insert k v b.left })
-insert k v (Branch b) = Branch (b { right = insert k v b.right })
-
+singleton k v = Two Leaf k v Leaf
+  
+checkValid :: forall k v. Map k v -> Boolean
+checkValid tree = A.length (A.nub (allHeights tree)) P.== 1
+  where
+  allHeights :: forall k v. Map k v -> [Number]
+  allHeights Leaf = [0]
+  allHeights (Two left _ _ right) = A.map (\n -> n P.+ 1) (allHeights left P.++ allHeights right)
+  allHeights (Three left _ _ mid _ _ right) = A.map (\n -> n P.+ 1) (allHeights left P.++ allHeights mid P.++ allHeights right)  
+  
 lookup :: forall k v. (P.Ord k) => k -> Map k v -> Maybe v
-lookup k Leaf = Nothing
-lookup k (Branch { key = k1, value = v }) | k P.== k1 = Just v
-lookup k (Branch { key = k1, left = left }) | k P.< k1 = lookup k left
-lookup k (Branch { right = right }) = lookup k right
+lookup _ Leaf = Nothing
+lookup k (Two _ k1 v _) | k P.== k1 = Just v
+lookup k (Two left k1 _ _) | k P.< k1 = lookup k left
+lookup k (Two _ _ _ right) = lookup k right
+lookup k (Three _ k1 v1 _ _ _ _) | k P.== k1 = Just v1
+lookup k (Three _ _ _ _ k2 v2 _) | k P.== k2 = Just v2
+lookup k (Three left k1 _ _ _ _ _) | k P.< k1 = lookup k left
+lookup k (Three _ k1 _ mid k2 _ _) | k1 P.< k P.&& k P.<= k2 = lookup k mid
+lookup k (Three _ _ _ _ _ _ right) = lookup k right
 
 member :: forall k v. (P.Ord k) => k -> Map k v -> Boolean
 member k m = isJust (k `lookup` m)
 
-findMinKey :: forall k v. (P.Ord k) => Map k v -> Tuple k v
-findMinKey (Branch { key = k, value = v, left = Leaf }) = Tuple k v
-findMinKey (Branch b) = findMinKey b.left
+data TreeContext k v
+  = TwoLeft k v (Map k v)
+  | TwoRight (Map k v) k v
+  | ThreeLeft k v (Map k v) k v (Map k v)
+  | ThreeMiddle (Map k v) k v k v (Map k v)
+  | ThreeRight (Map k v) k v (Map k v) k v
+  
+fromZipper :: forall k v. (P.Ord k) => [TreeContext k v] -> Map k v -> Map k v
+fromZipper [] tree = tree
+fromZipper (TwoLeft k1 v1 right : ctx) left = fromZipper ctx (Two left k1 v1 right)
+fromZipper (TwoRight left k1 v1 : ctx) right = fromZipper ctx (Two left k1 v1 right)
+fromZipper (ThreeLeft k1 v1 mid k2 v2 right : ctx) left = fromZipper ctx (Three left k1 v1 mid k2 v2 right)
+fromZipper (ThreeMiddle left k1 v1 k2 v2 right : ctx) mid = fromZipper ctx (Three left k1 v1 mid k2 v2 right)
+fromZipper (ThreeRight left k1 v1 mid k2 v2 : ctx) right = fromZipper ctx (Three left k1 v1 mid k2 v2 right)
+  
+data KickUp k v = KickUp (Map k v) k v (Map k v)
 
+insert :: forall k v. (P.Ord k) => k -> v -> Map k v -> Map k v
+insert = down []
+  where
+  down :: forall k v. (P.Ord k) => [TreeContext k v] -> k -> v -> Map k v -> Map k v
+  down ctx k v Leaf = up ctx (KickUp Leaf k v Leaf)
+  down ctx k v (Two left k1 _ right) | k P.== k1 = fromZipper ctx (Two left k v right)
+  down ctx k v (Two left k1 v1 right) | k P.< k1 = down (TwoLeft k1 v1 right P.: ctx) k v left
+  down ctx k v (Two left k1 v1 right) = down (TwoRight left k1 v1 P.: ctx) k v right
+  down ctx k v (Three left k1 _ mid k2 v2 right) | k P.== k1 = fromZipper ctx (Three left k v mid k2 v2 right)
+  down ctx k v (Three left k1 v1 mid k2 _ right) | k P.== k2 = fromZipper ctx (Three left k1 v1 mid k v right)
+  down ctx k v (Three left k1 v1 mid k2 v2 right) | k P.< k1 = down (ThreeLeft k1 v1 mid k2 v2 right P.: ctx) k v left
+  down ctx k v (Three left k1 v1 mid k2 v2 right) | k1 P.< k P.&& k P.<= k2 = down (ThreeMiddle left k1 v1 k2 v2 right P.: ctx) k v mid
+  down ctx k v (Three left k1 v1 mid k2 v2 right) = down (ThreeRight left k1 v1 mid k2 v2 P.: ctx) k v right  
+    
+  up :: forall k v. (P.Ord k) => [TreeContext k v] -> KickUp k v -> Map k v
+  up [] (KickUp left k v right) = Two left k v right
+  up (TwoLeft k1 v1 right : ctx) (KickUp left k v mid) = fromZipper ctx (Three left k v mid k1 v1 right)
+  up (TwoRight left k1 v1 : ctx) (KickUp mid k v right) = fromZipper ctx (Three left k1 v1 mid k v right)
+  up (ThreeLeft k1 v1 c k2 v2 d : ctx) (KickUp a k v b) = up ctx (KickUp (Two a k v b) k1 v1 (Two c k2 v2 d))
+  up (ThreeMiddle a k1 v1 k2 v2 d : ctx) (KickUp b k v c) = up ctx (KickUp (Two a k1 v1 b) k v (Two c k2 v2 d))
+  up (ThreeRight a k1 v1 b k2 v2 : ctx) (KickUp c k v d) = up ctx (KickUp (Two a k1 v1 b) k2 v2 (Two c k v d)) 
+  
 delete :: forall k v. (P.Ord k) => k -> Map k v -> Map k v
-delete k Leaf = Leaf
-delete k (Branch b@{ key = k1, left = Leaf }) | k P.== k1 =
-  case b of
-    { left = Leaf } -> b.right
-    { right = Leaf } -> b.left
-    _ -> glue b.left b.right
-delete k (Branch b@{ key = k1 }) | k P.< k1 = Branch (b { left = delete k b.left })
-delete k (Branch b) = Branch (b { right = delete k b.right })
-
+delete = down []
+  where
+  down :: forall k v. (P.Ord k) => [TreeContext k v] -> k -> Map k v -> Map k v
+  down ctx _ Leaf = fromZipper ctx Leaf
+  down ctx k (Two Leaf k1 _ Leaf) | k P.== k1 = up ctx Leaf
+  down ctx k (Two left k1 _ right) | k P.== k1 = 
+    let max = maxNode left
+    in removeMaxNode (TwoLeft max.key max.value right P.: ctx) left
+  down ctx k (Two left k1 v1 right) | k P.< k1 = down (TwoLeft k1 v1 right P.: ctx) k left
+  down ctx k (Two left k1 v1 right) = down (TwoRight left k1 v1 P.: ctx) k right
+  down ctx k (Three Leaf k1 _ Leaf k2 v2 Leaf) | k P.== k1 = fromZipper ctx (Two Leaf k2 v2 Leaf)
+  down ctx k (Three Leaf k1 v1 Leaf k2 _ Leaf) | k P.== k2 = fromZipper ctx (Two Leaf k1 v1 Leaf)
+  down ctx k (Three left k1 _ mid k2 v2 right) | k P.== k1 = 
+    let max = maxNode left
+    in removeMaxNode (ThreeLeft max.key max.value mid k2 v2 right P.: ctx) left
+  down ctx k (Three left k1 v1 mid k2 _ right) | k P.== k2 =
+    let max = maxNode mid
+    in removeMaxNode (ThreeMiddle left k1 v1 max.key max.value right P.: ctx) mid
+  down ctx k (Three left k1 v1 mid k2 v2 right) | k P.< k1 = down (ThreeLeft k1 v1 mid k2 v2 right P.: ctx) k left
+  down ctx k (Three left k1 v1 mid k2 v2 right) | k1 P.< k P.&& k P.< k2  = down (ThreeMiddle left k1 v1 k2 v2 right P.: ctx) k mid
+  down ctx k (Three left k1 v1 mid k2 v2 right) = down (ThreeRight left k1 v1 mid k2 v2 P.: ctx) k right  
+  
+  up :: forall k v. (P.Ord k) => [TreeContext k v] -> Map k v -> Map k v
+  up [] tree = tree
+  up (TwoLeft k1 v1 Leaf : ctx) Leaf = fromZipper ctx (Two Leaf k1 v1 Leaf)
+  up (TwoRight Leaf k1 v1 : ctx) Leaf = fromZipper ctx (Two Leaf k1 v1 Leaf)
+  up (TwoLeft k1 v1 (Two m k2 v2 r) : ctx) l = up ctx (Three l k1 v1 m k2 v2 r)
+  up (TwoRight (Two l k1 v1 m) k2 v2 : ctx) r = up ctx (Three l k1 v1 m k2 v2 r)
+  up (TwoLeft k1 v1 (Three b k2 v2 c k3 v3 d) : ctx) a = fromZipper ctx (Two (Two a k1 v1 b) k2 v2 (Two c k3 v3 d))
+  up (TwoRight (Three a k1 v1 b k2 v2 c) k3 v3 : ctx) d = fromZipper ctx (Two (Two a k1 v1 b) k2 v2 (Two c k3 v3 d))
+  up (ThreeLeft k1 v1 Leaf k2 v2 Leaf : ctx) Leaf = fromZipper ctx (Three Leaf k1 v1 Leaf k2 v2 Leaf)
+  up (ThreeMiddle Leaf k1 v1 k2 v2 Leaf : ctx) Leaf = fromZipper ctx (Three Leaf k1 v1 Leaf k2 v2 Leaf)
+  up (ThreeRight Leaf k1 v1 Leaf k2 v2 : ctx) Leaf = fromZipper ctx (Three Leaf k1 v1 Leaf k2 v2 Leaf)
+  up (ThreeLeft k1 v1 (Two b k2 v2 c) k3 v3 d : ctx) a = fromZipper ctx (Two (Three a k1 v1 b k2 v2 c) k3 v3 d)
+  up (ThreeMiddle (Two a k1 v1 b) k2 v2 k3 v3 d : ctx) c = fromZipper ctx (Two (Three a k1 v1 b k2 v2 c) k3 v3 d)
+  up (ThreeMiddle a k1 v1 k2 v2 (Two c k3 v3 d) : ctx) b = fromZipper ctx (Two a k1 v1 (Three b k2 v2 c k3 v3 d))
+  up (ThreeRight a k1 v1 (Two b k2 v2 c) k3 v3 : ctx) d = fromZipper ctx (Two a k1 v1 (Three b k2 v2 c k3 v3 d))
+  up (ThreeLeft k1 v1 (Three b k2 v2 c k3 v3 d) k4 v4 e : ctx) a = fromZipper ctx (Three (Two a k1 v1 b) k2 v2 (Two c k3 v3 d) k4 v4 e)
+  up (ThreeMiddle (Three a k1 v1 b k2 v2 c) k3 v3 k4 v4 e : ctx) d = fromZipper ctx (Three (Two a k1 v1 b) k2 v2 (Two c k3 v3 d) k4 v4 e)
+  up (ThreeMiddle a k1 v1 k2 v2 (Three c k3 v3 d k4 v4 e) : ctx) b = fromZipper ctx (Three a k1 v1 (Two b k2 v2 c) k3 v3 (Two d k4 v4 e))
+  up (ThreeRight a k1 v1 (Three b k2 v2 c k3 v3 d) k4 v4 : ctx) e = fromZipper ctx (Three a k1 v1 (Two b k2 v2 c) k3 v3 (Two d k4 v4 e))
+  
+  maxNode :: forall k v. (P.Ord k) => Map k v -> { key :: k, value :: v }
+  maxNode (Two _ k v Leaf) = { key: k, value: v }
+  maxNode (Two _ _ _ right) = maxNode right
+  maxNode (Three _ _ _ _ k v Leaf) = { key: k, value: v }
+  maxNode (Three _ _ _ _ _ _ right) = maxNode right
+  
+  removeMaxNode :: forall k v. (P.Ord k) => [TreeContext k v] -> Map k v -> Map k v
+  removeMaxNode ctx (Two Leaf _ _ Leaf) = up ctx Leaf
+  removeMaxNode ctx (Two left k v right) = removeMaxNode (TwoRight left k v P.: ctx) right
+  removeMaxNode ctx (Three Leaf k1 v1 Leaf _ _ Leaf) = up (TwoRight Leaf k1 v1 P.: ctx) Leaf
+  removeMaxNode ctx (Three left k1 v1 mid k2 v2 right) = removeMaxNode (ThreeRight left k1 v1 mid k2 v2 P.: ctx) right
+  
 alter :: forall k v. (P.Ord k) => (Maybe v -> Maybe v) -> k -> Map k v -> Map k v
-alter f k Leaf = case f Nothing of
-  Nothing -> Leaf
-  Just v -> singleton k v
-alter f k (Branch b@{ key = k1, value = v }) | k P.== k1 = case f (Just v) of
-  Nothing -> glue b.left b.right
-  Just v' -> Branch (b { value = v' })
-alter f k (Branch b@{ key = k1 }) | k P.< k1 = Branch (b { left = alter f k b.left })
-alter f k (Branch b) = Branch (b { right = alter f k b.right })
+alter f k m = case f (k `lookup` m) of
+  Nothing -> delete k m
+  Just v -> insert k v m
 
 update :: forall k v. (P.Ord k) => (v -> Maybe v) -> k -> Map k v -> Map k v
-update f k m = alter (maybe Nothing f) k m
-
-glue :: forall k v. (P.Ord k) => Map k v -> Map k v -> Map k v
-glue left right = 
-  case findMinKey right of
-    Tuple minKey root -> Branch { key: minKey, value: root, left: left, right: delete minKey right }
-
+update f k m = alter (maybe Nothing f) k m  
+  
 toList :: forall k v. Map k v -> [Tuple k v]
 toList Leaf = []
-toList (Branch b) = toList b.left P.++ [Tuple b.key b.value] P.++ toList b.right
+toList (Two left k v right) = toList left P.++ [Tuple k v] P.++ toList right
+toList (Three left k1 v1 mid k2 v2 right) = toList left P.++ [Tuple k1 v1] P.++ toList mid P.++ [Tuple k2 v2] P.++ toList right
 
 fromList :: forall k v. (P.Ord k) => [Tuple k v] -> Map k v
 fromList = foldl (\m (Tuple k v) -> insert k v m) empty
 
 keys :: forall k v. Map k v -> [k]
 keys Leaf = []
-keys (Branch b) = keys b.left P.++ [b.key] P.++ keys b.right
+keys (Two left k _ right) = keys left P.++ [k] P.++ keys right
+keys (Three left k1 _ mid k2 _ right) = keys left P.++ [k1] P.++ keys mid P.++ [k2] P.++ keys right
 
 values :: forall k v. Map k v -> [v]
 values Leaf = []
-values (Branch b) = values b.left P.++ [b.value] P.++ values b.right
+values (Two left _ v right) = values left P.++ [v] P.++ values right
+values (Three left _ v1 mid _ v2 right) = values left P.++ [v1] P.++ values mid P.++ [v2] P.++ values right
 
 union :: forall k v. (P.Ord k) => Map k v -> Map k v -> Map k v
 union m1 m2 = foldl (\m (Tuple k v) -> insert k v m) m2 (toList m1)
@@ -107,6 +224,5 @@ union m1 m2 = foldl (\m (Tuple k v) -> insert k v m) m2 (toList m1)
 unions :: forall k v. (P.Ord k) => [Map k v] -> Map k v
 unions = foldl union empty
 
-map :: forall k v1 v2. (P.Ord k) => (v1 -> v2) -> Map k v1 -> Map k v2
-map _ Leaf = Leaf
-map f (Branch b) = Branch (b { value = f b.value, left = map f b.left, right = map f b.right })
+map :: forall k a b. (a -> b) -> Map k a -> Map k b
+map = P.(<$>)

--- a/src/Data/Set.purs
+++ b/src/Data/Set.purs
@@ -1,7 +1,15 @@
-module Data.Set
+--
+-- Sets as balanced 2-3 trees
+--
+-- Based on http://www.cs.princeton.edu/~dpw/courses/cos326-12/ass/2-3-trees.pdf
+--
+
+module Data.Set 
   ( Set(),
     empty,
+    isEmpty,
     singleton,
+    checkValid,
     insert,
     member,
     delete,
@@ -10,65 +18,54 @@ module Data.Set
     union,
     unions
   ) where
-
+  
 import qualified Prelude as P
 
-import Data.Array (concat)
-import Data.Foldable (foldl)
-import Data.Maybe
-import Data.Tuple
+import qualified Data.Map as M
 
-data Set a = Leaf | Branch { value :: a, left :: Set a, right :: Set a }
+import Data.Array (map, nub, length)
+import Data.Maybe 
+import Data.Tuple
+import Data.Foldable (foldl) 
+  
+data Set a = Set (M.Map a P.Unit) 
 
 instance eqSet :: (P.Eq a) => P.Eq (Set a) where
-  (==) s1 s2 = toList s1 P.== toList s2
-  (/=) s1 s2 = P.not (s1 P.== s2)
+  (==) (Set m1) (Set m2) = m1 P.== m2
+  (/=) (Set m1) (Set m2) = m1 P./= m2
 
 instance showSet :: (P.Show a) => P.Show (Set a) where
   show s = "fromList " P.++ P.show (toList s)
-
+  
 empty :: forall a. Set a
-empty = Leaf
+empty = Set M.empty
+
+isEmpty :: forall a. Set a -> Boolean
+isEmpty (Set m) = M.isEmpty m
 
 singleton :: forall a. a -> Set a
-singleton a = Branch { value: a, left: empty, right: empty }
+singleton a = Set (M.singleton a P.unit)
+  
+checkValid :: forall a. Set a -> Boolean
+checkValid (Set m) = M.checkValid m
 
-insert :: forall a. (P.Eq a, P.Ord a) => a -> Set a -> Set a
-insert a Leaf = singleton a
-insert a (Branch b@{ value = a1 }) | a P.== a1 = Branch b
-insert a (Branch b@{ value = a1 }) | a P.< a1 = Branch (b { left = insert a b.left })
-insert a (Branch b) = Branch (b { right = insert a b.right })
+member :: forall a. (P.Ord a) => a -> Set a -> Boolean
+member a (Set m) = a `M.member` m
 
-member :: forall a. (P.Eq a, P.Ord a) => a -> Set a -> Boolean
-member _ Leaf = false
-member a (Branch { value = a1 }) | a P.== a1 = true
-member a (Branch { value = a1, left = left }) | a P.< a1 = member a left
-member a (Branch { right = right }) = member a right
-
-findMinValue :: forall a. (P.Ord a) => Set a -> a
-findMinValue (Branch { value = a, left = Leaf }) = a
-findMinValue (Branch b) = findMinValue b.left
-
-delete :: forall a. (P.Eq a, P.Ord a) => a -> Set a -> Set a
-delete _ Leaf = Leaf
-delete a (Branch b@{ value = a1, left = Leaf }) | a P.== a1 =
-  case b of
-    { left = Leaf } -> b.right
-    { right = Leaf } -> b.left
-    _ -> let minValue = findMinValue b.right in
-         Branch (b { value = minValue, right = delete minValue b.right })
-delete a (Branch b@{ value = a1 }) | a P.< a1 = Branch (b { left = delete a b.left })
-delete a (Branch b) = Branch (b { right = delete a b.right })
-
+insert :: forall a. (P.Ord a) => a -> Set a -> Set a
+insert a (Set m) = Set (M.insert a P.unit m)
+  
+delete :: forall a. (P.Ord a) => a -> Set a -> Set a
+delete a (Set m) = Set (a `M.delete` m)
+  
 toList :: forall a. Set a -> [a]
-toList Leaf = []
-toList (Branch b) = toList b.left P.++ [b.value] P.++ toList b.right
+toList (Set m) = map fst (M.toList m)
 
-fromList :: forall a. (P.Eq a, P.Ord a) => [a] -> Set a
-fromList = foldl (\s a -> insert a s) empty
+fromList :: forall a. (P.Ord a) => [a] -> Set a
+fromList = foldl (\m a -> insert a m) empty
 
-union :: forall a. (P.Eq a, P.Ord a) => Set a -> Set a -> Set a
-union s1 s2 = foldl (\s a -> insert a s) s2 (toList s1)
+union :: forall a. (P.Ord a) => Set a -> Set a -> Set a
+union (Set m1) (Set m2) = Set (m1 `M.union` m2)
 
 unions :: forall a. (P.Ord a) => [Set a] -> Set a
 unions = foldl union empty

--- a/tests/Tests.purs
+++ b/tests/Tests.purs
@@ -1,11 +1,12 @@
 module Tests where
 
-import Prelude
-import Data.Maybe
-import Data.Array
 import Debug.Trace
-import Control.Monad.Eff
+
+import Data.Maybe
 import Data.Tuple
+import Data.Array (map)
+import Data.Function (on)
+import Data.Foldable (foldl)
 
 import Test.QuickCheck
 import Test.QuickCheck.Tuple
@@ -13,120 +14,192 @@ import Test.QuickCheck.Tuple
 import qualified Data.Map as M
 import qualified Data.Set as S
 
-import Data.Graph
-
 instance arbMap :: (Eq k, Ord k, Arbitrary k, Arbitrary v) => Arbitrary (M.Map k v) where
   arbitrary = M.fromList <<< map runTestTuple <$> arbitrary
 
 instance arbSet :: (Eq a, Ord a, Arbitrary a) => Arbitrary (S.Set a) where
   arbitrary = S.fromList <$> arbitrary
 
-main = do
-  -- Data.Map
+data SmallKey = A | B | C | D | E | F | G | H | I | J
 
-  trace "testLookupEmpty: lookup _ empty == Nothing"
-  quickCheck $ \k -> M.lookup k (M.empty :: M.Map Number Number) == Nothing
+instance showSmallKey :: Show SmallKey where
+  show A = "A"
+  show B = "B"
+  show C = "C"
+  show D = "D"
+  show E = "E"
+  show F = "F"
+  show G = "G"
+  show H = "H"
+  show I = "I"
+  show J = "J"
 
-  trace "testLookupSingleton: lookup k (singleton k v) == Just v"
-  quickCheck $ \k v -> M.lookup (k :: Number) (M.singleton k (v :: Number)) == Just v
-
-  trace "testInsertTwo: lookup k (insert k v1 (insert k v2) empty) == Just v1"
-  quickCheck $ \k v1 v2 -> (M.lookup (k :: Number) $ 
-                              M.insert k (v1 :: Number) $ 
-                              M.insert k (v2 :: Number) M.empty) == Just v1
-
-  trace "testInsertDelete: lookup k (delete k (insert k v empty) = Nothing)"
-  quickCheck $ \k v -> (M.lookup (k :: Number) $ 
-                          M.delete k $ 
-                          M.insert k (v :: Number) M.empty) == Nothing
-
-  trace "testSingletonToList: toList (singleton k v) == [Tuple k v]"
-  quickCheck $ \k v -> M.toList (M.singleton k v :: M.Map Number Number) == [Tuple k v]
-
-  trace "testToListFromList: toList . fromList = id"
-  quickCheck $ \arr -> let f x = M.toList (M.fromList x) 
-                           arr' = map runTestTuple arr
-                       in f (f arr') == f (arr' :: [Tuple Number Number])
-
-  trace "testFromListToList: fromList . toList = id"
-  quickCheck $ \m -> let f m = M.fromList (M.toList m) in
-                     M.toList (f m) == M.toList (m :: M.Map Number Number)
+instance eqSmallKey :: Eq SmallKey where
+  (==) A A = true
+  (==) B B = true
+  (==) C C = true
+  (==) D D = true
+  (==) E E = true
+  (==) F F = true
+  (==) G G = true
+  (==) H H = true
+  (==) I I = true
+  (==) J J = true
+  (==) _ _ = false
+  (/=) x y = not (x == y)
   
-  trace "testUnionSymmetric: union m1 m2 == union m2 m1"
-  quickCheck $ \m1 m2 -> let m3 = m1 `M.union` (m2 :: M.Map Number Number) in
-                         let m4 = m2 `M.union` m1 in
-                         M.toList m3 == M.toList m4
+smallKeyToNumber :: SmallKey -> Number
+smallKeyToNumber A = 0
+smallKeyToNumber B = 1
+smallKeyToNumber C = 2
+smallKeyToNumber D = 3
+smallKeyToNumber E = 4
+smallKeyToNumber F = 5
+smallKeyToNumber G = 6
+smallKeyToNumber H = 7
+smallKeyToNumber I = 8
+smallKeyToNumber J = 9 
 
-  trace "testUnionIdempotent"
-  quickCheck $ \m1 m2 -> (m1 `M.union` m2) == ((m1 `M.union` m2) `M.union` (m2 :: M.Map Number Number))
+instance ordSmallKey :: Ord SmallKey where
+  compare = compare `on` smallKeyToNumber
 
+instance arbSmallKey :: Arbitrary SmallKey where
+  arbitrary = do
+    n <- arbitrary
+    return case n of
+      _ | n < 0.1 -> A
+      _ | n < 0.2 -> B
+      _ | n < 0.3 -> C
+      _ | n < 0.4 -> D
+      _ | n < 0.5 -> E
+      _ | n < 0.6 -> F
+      _ | n < 0.7 -> G
+      _ | n < 0.8 -> H
+      _ | n < 0.9 -> I
+      _ -> J
+
+data Instruction k v = Insert k v | Delete k
+
+instance showInstruction :: (Show k, Show v) => Show (Instruction k v) where
+  show (Insert k v) = "Insert (" ++ show k ++ ") (" ++ show v ++ ")"
+  show (Delete k) = "Delete (" ++ show k ++ ")"
+
+instance arbInstruction :: (Arbitrary k, Arbitrary v) => Arbitrary (Instruction k v) where
+  arbitrary = do
+    b <- arbitrary
+    case b of
+      true -> do
+        k <- arbitrary
+        v <- arbitrary
+        return (Insert k v)
+      false -> do
+        k <- arbitrary
+        return (Delete k)
+      
+runInstructions :: forall k v. (Ord k) => [Instruction k v] -> M.Map k v -> M.Map k v
+runInstructions instrs t0 = foldl step t0 instrs
+  where
+  step tree (Insert k v) = M.insert k v tree
+  step tree (Delete k) = M.delete k tree
+
+smallKey :: SmallKey -> SmallKey
+smallKey k = k
+
+number :: Number -> Number
+number n = n
+
+main = do
+  
+  -- Data.Map
+  
+  trace "Test inserting into empty tree"
+  quickCheck $ \k v -> M.lookup (smallKey k) (M.insert k v M.empty) == Just (number v)
+    <?> ("k: " ++ show k ++ ", v: " ++ show v)
+
+  trace "Test delete after inserting"
+  quickCheck $ \k v -> M.isEmpty (M.delete (smallKey k) (M.insert k (number v) M.empty)) 
+    <?> ("k: " ++ show k ++ ", v: " ++ show v)
+
+  trace "Insert two, lookup first"
+  quickCheck $ \k1 v1 k2 v2 -> k1 == k2 || M.lookup k1 (M.insert (smallKey k2) (number v2) (M.insert (smallKey k1) (number v1) M.empty)) == Just v1 
+    <?> ("k1: " ++ show k1 ++ ", v1: " ++ show v1 ++ ", k2: " ++ show k2 ++ ", v2: " ++ show v2)
+
+  trace "Insert two, lookup second"
+  quickCheck $ \k1 v1 k2 v2 -> M.lookup k2 (M.insert (smallKey k2) (number v2) (M.insert (smallKey k1) (number v1) M.empty)) == Just v2  
+    <?> ("k1: " ++ show k1 ++ ", v1: " ++ show v1 ++ ", k2: " ++ show k2 ++ ", v2: " ++ show v2)
+
+  trace "Insert two, delete one"
+  quickCheck $ \k1 v1 k2 v2 -> k1 == k2 || M.lookup k2 (M.delete k1 (M.insert (smallKey k2) (number v2) (M.insert (smallKey k1) (number v1) M.empty))) == Just v2 
+    <?> ("k1: " ++ show k1 ++ ", v1: " ++ show v1 ++ ", k2: " ++ show k2 ++ ", v2: " ++ show v2)
+  
+  trace "Check balance property"
+  quickCheck' 5000 $ \instrs -> 
+    let
+      tree :: M.Map SmallKey Number
+      tree = runInstructions instrs M.empty
+    in M.checkValid tree <?> ("Map not balanced:\n  " ++ show tree ++ "\nGenerated by:\n  " ++ show instrs)
+    
+  trace "Lookup from empty"
+  quickCheck $ \k -> M.lookup k (M.empty :: M.Map SmallKey Number) == Nothing
+
+  trace "Lookup from singleton"
+  quickCheck $ \k v -> M.lookup (k :: SmallKey) (M.singleton k (v :: Number)) == Just v
+
+  trace "Random lookup"
+  quickCheck' 5000 $ \instrs k v ->
+    let
+      tree :: M.Map SmallKey Number
+      tree = M.insert k v (runInstructions instrs M.empty)
+    in M.lookup k tree == Just v <?> ("instrs:\n  " ++ show instrs ++ "\nk:\n  " ++ show k ++ "\nv:\n  " ++ show v)
+
+  trace "Singleton to list"
+  quickCheck $ \k v -> M.toList (M.singleton k v :: M.Map SmallKey Number) == [Tuple k v]
+
+  trace "toList . fromList = id"
+  quickCheck $ \arr -> let f x = M.toList (M.fromList x) 
+                           arr' = runTestTuple <$> arr
+                       in f (f arr') == f (arr' :: [Tuple SmallKey Number]) <?> show arr
+
+  trace "fromList . toList = id"
+  quickCheck $ \m -> let f m = M.fromList (M.toList m) in
+                     M.toList (f m) == M.toList (m :: M.Map SmallKey Number) <?> show m
+  
+  trace "Lookup from union"
+  quickCheck $ \m1 m2 k -> M.lookup (smallKey k) (M.union m1 m2) == (case M.lookup k m1 of 
+    Nothing -> M.lookup k m2
+    Just v -> Just (number v)) <?> ("m1: " ++ show m1 ++ ", m2: " ++ show m2 ++ ", k: " ++ show k ++ ", v1: " ++ show (M.lookup k m1) ++ ", v2: " ++ show (M.lookup k m2) ++ ", union: " ++ show (M.union m1 m2))
+ 
+  trace "Union is idempotent"
+  quickCheck $ \m1 m2 -> (m1 `M.union` m2) == ((m1 `M.union` m2) `M.union` (m2 :: M.Map SmallKey Number))
+  
   -- Data.Set
 
   trace "testMemberEmpty: member _ empty == false"
-  quickCheck $ \a -> S.member a (S.empty :: S.Set Number) == false
+  quickCheck $ \a -> S.member a (S.empty :: S.Set SmallKey) == false
 
   trace "testMemberSingleton: member a (singleton a) == true"
-  quickCheck $ \a -> S.member (a :: Number) (S.singleton a) == true
+  quickCheck $ \a -> S.member (a :: SmallKey) (S.singleton a) == true
 
   trace "testInsertDelete: member a (delete a (insert a empty) == false)"
-  quickCheck $ \a -> (S.member (a :: Number) $ 
+  quickCheck $ \a -> (S.member (a :: SmallKey) $ 
                           S.delete a $ 
                           S.insert a S.empty) == false
 
   trace "testSingletonToList: toList (singleton a) == [a]"
-  quickCheck $ \a -> S.toList (S.singleton a :: S.Set Number) == [a]
+  quickCheck $ \a -> S.toList (S.singleton a :: S.Set SmallKey) == [a]
 
   trace "testToListFromList: toList . fromList = id"
   quickCheck $ \arr -> let f x = S.toList (S.fromList x) in
-                           f (f arr) == f (arr :: [Number])
+                           f (f arr) == f (arr :: [SmallKey])
 
   trace "testFromListToList: fromList . toList = id"
   quickCheck $ \s -> let f s = S.fromList (S.toList s) in
-                     S.toList (f s) == S.toList (s :: S.Set Number)
+                     S.toList (f s) == S.toList (s :: S.Set SmallKey)
 
   trace "testUnionSymmetric: union s1 s2 == union s2 s1"
-  quickCheck $ \s1 s2 -> let s3 = s1 `S.union` (s2 :: S.Set Number) in
+  quickCheck $ \s1 s2 -> let s3 = s1 `S.union` (s2 :: S.Set SmallKey) in
                          let s4 = s2 `S.union` s1 in
                          S.toList s3 == S.toList s4
 
   trace "testUnionIdempotent"
-  quickCheck $ \s1 s2 -> (s1 `S.union` s2) == ((s1 `S.union` s2) `S.union` (s2 :: S.Set Number))
-
-  -- Data.Graph
-
-  trace "testOneVertex"
-  quickCheck $ \v -> let g = Graph ([v] :: [Number]) [] in
-                     let comps = scc g in
-                     comps == [AcyclicSCC v]
-  
-  trace "testOneVertexCycle"
-  quickCheck $ \v -> let g = Graph ([v] :: [Number]) [Edge v v] in
-                     let comps = scc g in
-                     comps == [CyclicSCC [v]]
-  
-  trace "testOneComponent"
-  quickCheck $ \v1 v2 -> let g = Graph ([v1, v2] :: [Number]) [Edge v1 v2, Edge v2 v1] in
-                         let comps = scc g in
-                         comps == [CyclicSCC [v1, v2]] || comps == [CyclicSCC [v2, v1]]
-  
-  trace "testTwoComponents"
-  quickCheck $ \v1 v2 -> let g = Graph ([v1, v2] :: [Number]) [] in
-                         let comps = scc g in
-                         comps == [AcyclicSCC v1, AcyclicSCC v2] || comps == [AcyclicSCC v2, AcyclicSCC v1]
-
-  trace "testManyEdges"
-  quickCheck $ \vs -> let g = Graph (vs :: [Number]) (Edge <$> vs <*> vs) in
-                      vs == [] || length (scc g) == 1
-  
-  trace "testNoEdges"
-  quickCheck $ \vs -> let g = Graph (vs :: [Number]) [] in
-                      length (scc g) == length vs
-  
-  trace "testChain"
-  quickCheck $ \vs -> let g = Graph (vs :: [Number]) (reverse $ chain vs) in
-                      scc g == reverse (map AcyclicSCC vs)
-
-chain :: forall v. [v] -> [Edge v]
-chain [] = []
-chain [_] = []
-chain (v : tail@(w : _)) = Edge v w : chain tail
+  quickCheck $ \s1 s2 -> (s1 `S.union` s2) == ((s1 `S.union` s2) `S.union` (s2 :: S.Set SmallKey))


### PR DESCRIPTION
This change uses balanced 2-3 trees as the underlying map implementation to change expected bounds to worst case bounds. This seems to give a slight improvement in the performance of ps-in-ps.

`Data.Set` has been modified to use `Data.Map` under the hood, to save code.

The test suite is also improved.
