### PR TITLE
Fixes for 0.6.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
   
     pscMake: ["<%=libFiles%>"],
     dotPsci: ["<%=libFiles%>"],
-    docgen: {
+    pscDocs: {
         readme: {
             src: "src/**/*.purs",
             dest: "README.md"
@@ -47,6 +47,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks("grunt-execute");
   
   grunt.registerTask("test", ["clean:tests", "psc", "execute"]);
-  grunt.registerTask("make", ["pscMake", "dotPsci", "docgen"]);
+  grunt.registerTask("make", ["pscMake", "dotPsci", "pscDocs"]);
   grunt.registerTask("default", ["make", "test"]);
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "dependencies": {
     "grunt": "~0.4.4",
-    "grunt-purescript": "~0.5.1",
+    "grunt-purescript": "~0.6.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-execute": "~0.2.1"
   }

--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -159,9 +159,8 @@ delete = down []
                     in removeMaxNode (TwoLeft max.key max.value right P.: ctx) left
     | k P.< k1    = down (TwoLeft k1 v1 right P.: ctx) k left
     | P.otherwise = down (TwoRight left k1 v1 P.: ctx) k right
-  down ctx k (Three Leaf k1 _ Leaf k2 v2 Leaf) 
+  down ctx k (Three Leaf k1 v1 Leaf k2 v2 Leaf) 
     | k P.== k1 = fromZipper ctx (Two Leaf k2 v2 Leaf)
-  down ctx k (Three Leaf k1 v1 Leaf k2 _ Leaf) 
     | k P.== k2 = fromZipper ctx (Two Leaf k1 v1 Leaf)
   down ctx k (Three left k1 v1 mid k2 v2 right) 
     | k P.== k1 = let max = maxNode left


### PR DESCRIPTION
@garyb @joneshf Could you please review?

To parse multiple guards, every guard needs to be equally indented, and in 0.6.1 this means that the body of the guard needs to be more indented than its expression, which breaks `purescript-lists` and `purescript-maps`.
