### PR TITLE
Fix _copyEff not to directly reference _copy

### DIFF
--- a/src/Data/StrMap.purs
+++ b/src/Data/StrMap.purs
@@ -66,7 +66,11 @@ foreign import _copyEff
   """
   function _copyEff(m) {
     return function() {
-      return _copy(m);
+      var r = {};
+      for (var k in m) {
+        r[k] = m[k];
+      }
+      return r;
     };
   }
   """ :: forall a b h r. a -> Eff (st :: ST.ST h | r) b


### PR DESCRIPTION
Fixes #19.  This could directly pass in `_copy` or use `_copyEff` as an unsafe call, but it's only 4 lines so this seemed more efficient.
