### PR TITLE
Ord instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ instance showMap :: (Show k, Show v) => Show (Map k v)
 ```
 
 
+#### `ordMap`
+
+``` purescript
+instance ordMap :: (Ord k, Ord v) => Ord (Map k v)
+```
+
+
 #### `semigroupMap`
 
 ``` purescript

--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -46,6 +46,9 @@ instance eqMap :: (Eq k, Eq v) => Eq (Map k v) where
 instance showMap :: (Show k, Show v) => Show (Map k v) where
   show m = "fromList " ++ show (toList m)
 
+instance ordMap :: (Ord k, Ord v) => Ord (Map k v) where
+  compare m1 m2 = compare (toList m1) (toList m2)
+
 instance semigroupMap :: (Ord k) => Semigroup (Map k v) where
   (<>) = union
 


### PR DESCRIPTION
This implementation behaves the same as the Haskell implementation of `(Ord k, Ord v) => Ord (Map k v)` as purescripts `Map.toList` seems to behaves the same as haskells `Map.toAscList`.

Fixes #31 