### PR TITLE
fix peek to return Maybe, update docs

### DIFF
--- a/docs/Data/Map.md
+++ b/docs/Data/Map.md
@@ -175,7 +175,7 @@ of duplicate keys
 #### `unions`
 
 ``` purescript
-unions :: forall k v. (Ord k) => List (Map k v) -> Map k v
+unions :: forall k v f. (Ord k, Foldable f) => f (Map k v) -> Map k v
 ```
 
 Compute the union of a collection of maps

--- a/docs/Data/StrMap/ST.md
+++ b/docs/Data/StrMap/ST.md
@@ -27,7 +27,7 @@ Create a new, empty mutable map
 #### `peek`
 
 ``` purescript
-peek :: forall a h r. STStrMap h a -> String -> Eff (st :: ST h | r) a
+peek :: forall a h r. STStrMap h a -> String -> Eff (st :: ST h | r) (Maybe a)
 ```
 
 Get the value for a key in a mutable map

--- a/src/Data/StrMap/ST.js
+++ b/src/Data/StrMap/ST.js
@@ -12,7 +12,7 @@ exports.peekImpl = function (just) {
     return function (m) {
       return function (k) {
         return function () {
-          return m.hasOwnProperty(k) ? just(m[k]) : nothing;
+          return {}.hasOwnProperty.call(m, k) ? just(m[k]) : nothing;
         };
       };
     };

--- a/src/Data/StrMap/ST.js
+++ b/src/Data/StrMap/ST.js
@@ -7,10 +7,15 @@ exports["new"] = function () {
   return {};
 };
 
-exports.peek = function (m) {
-  return function (k) {
-    return function () {
-      return m[k];
+exports.peekImpl = function (just) {
+  return function (nothing) {
+    return function (m) {
+      return function (k) {
+        return function () {
+          var x = m[k];
+          return x === undefined ? nothing : just(x);
+        };
+      };
     };
   };
 };

--- a/src/Data/StrMap/ST.js
+++ b/src/Data/StrMap/ST.js
@@ -12,8 +12,7 @@ exports.peekImpl = function (just) {
     return function (m) {
       return function (k) {
         return function () {
-          var x = m[k];
-          return x === undefined ? nothing : just(x);
+          return m.hasOwnProperty(k) ? just(m[k]) : nothing;
         };
       };
     };

--- a/src/Data/StrMap/ST.purs
+++ b/src/Data/StrMap/ST.purs
@@ -14,6 +14,7 @@ import Prelude
 
 import Control.Monad.Eff (Eff())
 import Control.Monad.ST (ST())
+import Data.Maybe (Maybe(..))
 
 -- | A reference to a mutable map
 -- |
@@ -26,7 +27,10 @@ foreign import data STStrMap :: * -> * -> *
 foreign import new :: forall a h r. Eff (st :: ST h | r) (STStrMap h a)
 
 -- | Get the value for a key in a mutable map
-foreign import peek :: forall a h r. STStrMap h a -> String -> Eff (st :: ST h | r) a
+peek :: forall a h r. STStrMap h a -> String -> Eff (st :: ST h | r) (Maybe a)
+peek = peekImpl Just Nothing
+
+foreign import peekImpl :: forall a b h r. (a -> b) -> b -> STStrMap h a -> String -> Eff (st :: ST h | r) b
 
 -- | Update the value for a key in a mutable map
 foreign import poke :: forall a h r. STStrMap h a -> String -> a -> Eff (st :: ST h | r) (STStrMap h a)


### PR DESCRIPTION
After agreement in IRC w/ paf31, peek should really return something in Maybe otherwise `(SM.new >>= flip SM.peek "asdf") :: forall s. Eff (st :: ST s) String` returns `undefined`.

It looks like the docs for unions was also out of date, that change in the docs is unrelated to my code changes here.

Per discussion in IRC I followed the style of purescript-arrays' peek function in the implementation.