### PR TITLE
avoid collision with Object.prototype keys in StrMap using key transformation function

### DIFF
--- a/src/Data/StrMap.js
+++ b/src/Data/StrMap.js
@@ -3,10 +3,13 @@
 
 // module Data.StrMap
 
+function safeKey(x) { return "$" + x; }
+function unsafeKey(x) { return x.slice(1); }
+
 exports._copy = function (m) {
   var r = {};
   for (var k in m) {
-    if ({}.hasOwnProperty.call(m, k)) {
+    if (m.hasOwnProperty(k)) {
       r[k] = m[k];
     }
   }
@@ -17,7 +20,7 @@ exports._copyEff = function (m) {
   return function () {
     var r = {};
     for (var k in m) {
-      if ({}.hasOwnProperty.call(m, k)) {
+      if (m.hasOwnProperty(k)) {
         r[k] = m[k];
       }
     }
@@ -35,7 +38,7 @@ exports.runST = function (f) {
 exports._fmapStrMap = function (m0, f) {
   var m = {};
   for (var k in m0) {
-    if ({}.hasOwnProperty.call(m0, k)) {
+    if (m0.hasOwnProperty(k)) {
       m[k] = f(m0[k]);
     }
   }
@@ -49,12 +52,12 @@ exports._foldM = function (bind) {
       return function (m) {
         function g (k) {
           return function (z) {
-            return f(z)(k)(m[k]);
+            return f(z)(k)(m[safeKey(k)]);
           };
         }
         for (var k in m) {
-          if ({}.hasOwnProperty.call(m, k)) {
-            mz = bind(mz)(g(k));
+          if (m.hasOwnProperty(k)) {
+            mz = bind(mz)(g(unsafeKey(k)));
           }
         }
         return mz;
@@ -66,7 +69,7 @@ exports._foldM = function (bind) {
 // jshint maxparams: 4
 exports._foldSCStrMap = function (m, z, f, fromMaybe) {
   for (var k in m) {
-    if ({}.hasOwnProperty.call(m, k)) {
+    if (m.hasOwnProperty(k)) {
       var maybeR = f(z)(k)(m[k]);
       var r = fromMaybe(null)(maybeR);
       if (r === null) return z;
@@ -80,7 +83,7 @@ exports._foldSCStrMap = function (m, z, f, fromMaybe) {
 exports.all = function (f) {
   return function (m) {
     for (var k in m) {
-      if ({}.hasOwnProperty.call(m, k) && !f(k)(m[k])) return false;
+      if (m.hasOwnProperty(k) && !f(unsafeKey(k))(m[k])) return false;
     }
     return true;
   };
@@ -89,7 +92,7 @@ exports.all = function (f) {
 exports.size = function (m) {
   var s = 0;
   for (var k in m) {
-    if ({}.hasOwnProperty.call(m, k)) {
+    if (m.hasOwnProperty(k)) {
       ++s;
     }
   }
@@ -98,19 +101,19 @@ exports.size = function (m) {
 
 // jshint maxparams: 4
 exports._lookup = function (no, yes, k, m) {
-  return k in m ? yes(m[k]) : no;
+  return m.hasOwnProperty(safeKey(k)) ? yes(m[safeKey(k)]) : no;
 };
 
 // jshint maxparams: 2
 exports._unsafeDeleteStrMap = function (m, k) {
-  delete m[k];
+  delete m[safeKey(k)];
   return m;
 };
 
 // jshint maxparams: 4
 exports._lookupST = function (no, yes, k, m) {
   return function () {
-    return k in m ? yes(m[k]) : no;
+    return m.hasOwnProperty(safeKey(k)) ? yes(m[safeKey(k)]) : no;
   };
 };
 
@@ -118,8 +121,8 @@ function _collect (f) {
   return function (m) {
     var r = [];
     for (var k in m) {
-      if ({}.hasOwnProperty.call(m, k)) {
-        r.push(f(k)(m[k]));
+      if (m.hasOwnProperty(k)) {
+        r.push(f(unsafeKey(k))(m[k]));
       }
     }
     return r;
@@ -128,6 +131,6 @@ function _collect (f) {
 
 exports._collect = _collect;
 
-exports.keys = Object.keys || _collect(function (k) {
+exports.keys = _collect(function (k) {
   return function () { return k; };
 });

--- a/src/Data/StrMap.js
+++ b/src/Data/StrMap.js
@@ -6,7 +6,7 @@
 exports._copy = function (m) {
   var r = {};
   for (var k in m) {
-    if (m.hasOwnProperty(k)) {
+    if ({}.hasOwnProperty.call(m, k)) {
       r[k] = m[k];
     }
   }
@@ -17,7 +17,7 @@ exports._copyEff = function (m) {
   return function () {
     var r = {};
     for (var k in m) {
-      if (m.hasOwnProperty(k)) {
+      if ({}.hasOwnProperty.call(m, k)) {
         r[k] = m[k];
       }
     }
@@ -35,7 +35,7 @@ exports.runST = function (f) {
 exports._fmapStrMap = function (m0, f) {
   var m = {};
   for (var k in m0) {
-    if (m0.hasOwnProperty(k)) {
+    if ({}.hasOwnProperty.call(m0, k)) {
       m[k] = f(m0[k]);
     }
   }
@@ -53,7 +53,7 @@ exports._foldM = function (bind) {
           };
         }
         for (var k in m) {
-          if (m.hasOwnProperty(k)) {
+          if ({}.hasOwnProperty.call(m, k)) {
             mz = bind(mz)(g(k));
           }
         }
@@ -66,7 +66,7 @@ exports._foldM = function (bind) {
 // jshint maxparams: 4
 exports._foldSCStrMap = function (m, z, f, fromMaybe) {
   for (var k in m) {
-    if (m.hasOwnProperty(k)) {
+    if ({}.hasOwnProperty.call(m, k)) {
       var maybeR = f(z)(k)(m[k]);
       var r = fromMaybe(null)(maybeR);
       if (r === null) return z;
@@ -80,7 +80,7 @@ exports._foldSCStrMap = function (m, z, f, fromMaybe) {
 exports.all = function (f) {
   return function (m) {
     for (var k in m) {
-      if (m.hasOwnProperty(k) && !f(k)(m[k])) return false;
+      if ({}.hasOwnProperty.call(m, k) && !f(k)(m[k])) return false;
     }
     return true;
   };
@@ -89,7 +89,7 @@ exports.all = function (f) {
 exports.size = function (m) {
   var s = 0;
   for (var k in m) {
-    if (m.hasOwnProperty(k)) {
+    if ({}.hasOwnProperty.call(m, k)) {
       ++s;
     }
   }
@@ -118,7 +118,7 @@ function _collect (f) {
   return function (m) {
     var r = [];
     for (var k in m) {
-      if (m.hasOwnProperty(k)) {
+      if ({}.hasOwnProperty.call(m, k)) {
         r.push(f(k)(m[k]));
       }
     }

--- a/src/Data/StrMap/ST.js
+++ b/src/Data/StrMap/ST.js
@@ -3,6 +3,8 @@
 
 // module Data.StrMap.ST
 
+function safeKey(x) { return "$" + x; }
+
 exports["new"] = function () {
   return {};
 };
@@ -12,7 +14,7 @@ exports.peekImpl = function (just) {
     return function (m) {
       return function (k) {
         return function () {
-          return {}.hasOwnProperty.call(m, k) ? just(m[k]) : nothing;
+          return m.hasOwnProperty(safeKey(k)) ? just(m[safeKey(k)]) : nothing;
         };
       };
     };
@@ -23,7 +25,7 @@ exports.poke = function (m) {
   return function (k) {
     return function (v) {
       return function () {
-        m[k] = v;
+        m[safeKey(k)] = v;
         return m;
       };
     };
@@ -33,7 +35,7 @@ exports.poke = function (m) {
 exports["delete"] = function (m) {
   return function (k) {
     return function () {
-      delete m[k];
+      delete m[safeKey(k)];
       return m;
     };
   };

--- a/src/Data/StrMap/Unsafe.js
+++ b/src/Data/StrMap/Unsafe.js
@@ -3,8 +3,10 @@
 
 // module Data.StrMap.Unsafe
 
+function safeKey(x) { return "$" + x; }
+
 exports.unsafeIndex = function (m) {
   return function (k) {
-    return m[k];
+    return m[safeKey(k)];
   };
 };


### PR DESCRIPTION
This builds on top of #44 by @jbrownson. Not sure yet how to avoid duplicating the `safeKey` function in each `.js` file. I'd love to hear a suggestion.
