### PR TITLE
Get rid of compiler warnings

### DIFF
--- a/src/Data/StrMap.purs
+++ b/src/Data/StrMap.purs
@@ -69,7 +69,7 @@ freezeST = _copyEff
 -- | The rank-2 type prevents the map from escaping the scope of `runST`.
 foreign import runST :: forall a r. (forall h. Eff (st :: ST.ST h | r) (SM.STStrMap h a)) -> Eff r (StrMap a)
 
-pureST :: forall a b. (forall h e. Eff (st :: ST.ST h | e) (SM.STStrMap h a)) -> StrMap a
+pureST :: forall a. (forall h e. Eff (st :: ST.ST h | e) (SM.STStrMap h a)) -> StrMap a
 pureST f = runPure (runST f)
 
 mutate :: forall a b. (forall h e. SM.STStrMap h a -> Eff (st :: ST.ST h | e) b) -> StrMap a -> StrMap a

--- a/test/Test/Data/Map.purs
+++ b/test/Test/Data/Map.purs
@@ -8,10 +8,10 @@ import Data.Foldable (foldl, for_)
 import Data.Function (on)
 import Data.List (List(..), groupBy, length, nubBy, sortBy, singleton, toList)
 import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe.Unsafe (unsafeThrow)
 import Data.Tuple (Tuple(..), fst)
 import Test.QuickCheck ((<?>), quickCheck, quickCheck')
 import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
-import Test.QuickCheck.Gen (Gen(..))
 
 import qualified Data.Map as M
 
@@ -170,6 +170,7 @@ mapTests = do
   quickCheck $ \arr ->
     let combine (Tuple s a) (Tuple t b) = (Tuple s $ b <> a)
         foldl1 g (Cons x xs) = foldl g x xs
+        foldl1 _ Nil         = unsafeThrow "Impossible case in 'foldl1'"
         f = M.fromList <<< (<$>) (foldl1 combine) <<<
             groupBy ((==) `on` fst) <<< sortBy (compare `on` fst) in
     M.fromListWith (<>) arr == f (arr :: List (Tuple String String)) <?> show arr

--- a/test/Test/Data/StrMap.purs
+++ b/test/Test/Data/StrMap.purs
@@ -10,7 +10,6 @@ import Data.Tuple (Tuple(..), fst)
 import Control.Monad.Eff.Console (log)
 import Test.QuickCheck ((<?>), quickCheck, quickCheck')
 import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
-import Test.QuickCheck.Gen (Gen(..))
 import qualified Data.String as S
 import qualified Data.StrMap as M
 

--- a/test/Test/Data/StrMap.purs
+++ b/test/Test/Data/StrMap.purs
@@ -6,6 +6,7 @@ import Data.List (List(..), groupBy, sortBy, singleton, toList, zipWith)
 import Data.Foldable (foldl)
 import Data.Function (on)
 import Data.Maybe (Maybe(..))
+import Data.Maybe.Unsafe (unsafeThrow)
 import Data.Tuple (Tuple(..), fst)
 import Control.Monad.Eff.Console (log)
 import Test.QuickCheck ((<?>), quickCheck, quickCheck')
@@ -98,6 +99,7 @@ strMapTests = do
   quickCheck $ \arr ->
     let combine (Tuple s a) (Tuple t b) = (Tuple s $ b <> a)
         foldl1 g (Cons x xs) = foldl g x xs
+        foldl1 _ Nil         = unsafeThrow "Impossible case in 'foldl1'"
         f = M.fromList <<< (<$>) (foldl1 combine) <<<
             groupBy ((==) `on` fst) <<< sortBy (compare `on` fst) in
     M.fromListWith (<>) arr == f (arr :: List (Tuple String String)) <?> show arr


### PR DESCRIPTION
- impossible pattern matches (`unsafeThrow` in place)
- unused type variable
- unused imports