### PR TITLE
Changed a type  variable in an attempt to quelch shadow warnings.

### DIFF
--- a/src/Data/StrMap.purs
+++ b/src/Data/StrMap.purs
@@ -111,7 +111,7 @@ instance traversableStrMap :: Traversable StrMap where
 -- Unfortunately the above are not short-circuitable (consider using purescript-machines)
 -- so we need special cases:
 
-foreign import _foldSCStrMap :: forall a z. Fn4 (StrMap a) z (z -> String -> a -> Maybe z) (forall a. a -> Maybe a -> a) z
+foreign import _foldSCStrMap :: forall a z. Fn4 (StrMap a) z (z -> String -> a -> Maybe z) (forall b. b -> Maybe b -> b) z
 
 -- | Fold the keys and values of a map.
 -- |


### PR DESCRIPTION
This very well may be the wrong fix. Tests pass and the library compiles, but I wasn't sure if any of the a's from the first forall black were meant to some how carry over to the quantification specified in the second block. 

Perhaps I need to revisit Purescript By Example for this one?
This is the last of warnings produced in purescript/purescript#1063 that shouldn't require a compiler change.