### PR TITLE
fix toUnfoldable

### DIFF
--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -378,7 +378,7 @@ toUnfoldable = unfoldr go
   go :: Map k v -> Maybe (Tuple (Tuple k v) (Map k v))
   go Leaf = Nothing
   go (Two left k v right) = Just $ Tuple (Tuple k v) (left <> right)
-  go (Three left k1 v1 mid k2 v2 right) = Just $ Tuple (Tuple k1 v1) (Two left k2 v2 right)
+  go (Three left k1 v1 mid k2 v2 right) = Just $ Tuple (Tuple k1 v1) (insert k2 v2 (left <> mid <> right))
 
 -- | Get a list of the keys contained in a map
 keys :: forall k v. Map k v -> List k

--- a/test/Test/Data/Map.purs
+++ b/test/Test/Data/Map.purs
@@ -202,6 +202,10 @@ mapTests = do
   quickCheck $ \(TestMap m) -> let f m' = M.fromFoldable (M.toList m') in
                      M.toList (f m) == M.toList (m :: M.Map SmallKey Int) <?> show m
 
+  log "fromFoldable . toUnfoldable = id"
+  quickCheck $ \(TestMap m) -> let f m' = M.fromFoldable (M.toUnfoldable m' :: List (Tuple SmallKey Int)) in
+                     f m == (m :: M.Map SmallKey Int) <?> show m
+
   log "fromFoldableWith const = fromFoldable"
   quickCheck $ \arr -> M.fromFoldableWith const arr ==
                        M.fromFoldable (arr :: List (Tuple SmallKey Int)) <?> show arr


### PR DESCRIPTION
Hello,

The current `toUnfoldable` implementation loses whole of `mid` nodes. This PR just fixes it.