### PR TITLE
Added toAscUnfoldable

### DIFF
--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -381,9 +381,10 @@ fromFoldableWith f = foldl (\m (Tuple k v) -> alter (combine v) k m) empty where
   combine v (Just v') = Just $ f v v'
   combine v Nothing = Just v
 
--- | Convert a map to a list of key/value pairs
+-- | Convert a map to a list of key/value pairs.
+-- | DEPRECATED: use toUnfoldable or toAscUnfoldable instead.
 toList :: forall k v. Map k v -> List (Tuple k v)
-toList = toUnfoldable
+toList = toAscUnfoldable
 
 -- | Convert a map to an unfoldable structure of key/value pairs
 toUnfoldable :: forall f k v. Unfoldable f => Map k v -> f (Tuple k v)

--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -19,8 +19,8 @@ module Data.Map
   , fromFoldable
   , fromFoldableWith
   , toList
-  , toAscList
   , toUnfoldable
+  , toAscUnfoldable
   , delete
   , pop
   , member
@@ -36,7 +36,6 @@ module Data.Map
   ) where
 
 import Prelude
-
 import Data.Foldable (foldl, foldMap, foldr, class Foldable)
 import Data.List (List(..), (:), length, nub)
 import Data.Maybe (Maybe(..), maybe, isJust, fromMaybe)
@@ -44,7 +43,6 @@ import Data.Monoid (class Monoid)
 import Data.Traversable (traverse, class Traversable)
 import Data.Tuple (Tuple(Tuple), snd)
 import Data.Unfoldable (class Unfoldable, unfoldr)
-
 import Partial.Unsafe (unsafePartial)
 
 -- | `Map k v` represents maps from keys of type `k` to values of type `v`.
@@ -53,14 +51,18 @@ data Map k v
   | Two (Map k v) k v (Map k v)
   | Three (Map k v) k v (Map k v) k v (Map k v)
 
+-- Internal use
+toAscArray :: forall k v. Map k v -> Array (Tuple k v)
+toAscArray = toAscUnfoldable
+
 instance eqMap :: (Eq k, Eq v) => Eq (Map k v) where
-  eq m1 m2 = toAscList m1 == toAscList m2
+  eq m1 m2 = toAscArray m1 == toAscArray m2
 
 instance ordMap :: (Ord k, Ord v) => Ord (Map k v) where
-  compare m1 m2 = compare (toAscList m1) (toAscList m2)
+  compare m1 m2 = compare (toAscArray m1) (toAscArray m2)
 
 instance showMap :: (Show k, Show v) => Show (Map k v) where
-  show m = "(fromList " <> show (toAscList m) <> ")"
+  show m = "(fromFoldable " <> show (toAscArray m) <> ")"
 
 instance semigroupMap :: Ord k => Semigroup (Map k v) where
   append = union
@@ -381,13 +383,7 @@ fromFoldableWith f = foldl (\m (Tuple k v) -> alter (combine v) k m) empty where
 
 -- | Convert a map to a list of key/value pairs
 toList :: forall k v. Map k v -> List (Tuple k v)
-toList Leaf = Nil
-toList (Two left k v right) = toList left <> Tuple k v : toList right
-toList (Three left k1 v1 mid k2 v2 right) = toList left <> Tuple k1 v1 : toList mid <> Tuple k2 v2 : toList right
-
--- | Convert a map to a list of key/value pairs where the keys are in ascending order
-toAscList :: forall k v. Map k v -> List (Tuple k v)
-toAscList = toList
+toList = toUnfoldable
 
 -- | Convert a map to an unfoldable structure of key/value pairs
 toUnfoldable :: forall f k v. Unfoldable f => Map k v -> f (Tuple k v)
@@ -399,6 +395,21 @@ toUnfoldable m = unfoldr go (m : Nil) where
       Just $ Tuple (Tuple k v) (left : right : tl)
     Three left k1 v1 mid k2 v2 right ->
       Just $ Tuple (Tuple k1 v1) (singleton k2 v2 : left : mid : right : tl)
+
+-- | Convert a map to an unfoldable structure of key/value pairs where the keys are in ascending order
+toAscUnfoldable :: forall f k v. Unfoldable f => Map k v -> f (Tuple k v)
+toAscUnfoldable m = unfoldr go (m : Nil) where
+  go Nil = Nothing
+  go (hd : tl) = case hd of
+    Leaf -> go tl
+    Two Leaf k v Leaf ->
+      Just $ Tuple (Tuple k v) tl
+    Two Leaf k v right ->
+      Just $ Tuple (Tuple k v) (right : tl)
+    Two left k v right ->
+      go $ left : singleton k v : right : tl
+    Three left k1 v1 mid k2 v2 right ->
+      go $ left : singleton k1 v1 : mid : singleton k2 v2 : right : tl
 
 -- | Get a list of the keys contained in a map
 keys :: forall k v. Map k v -> List k

--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -19,6 +19,7 @@ module Data.Map
   , fromFoldable
   , fromFoldableWith
   , toList
+  , toAscList
   , toUnfoldable
   , delete
   , pop
@@ -383,6 +384,10 @@ toList :: forall k v. Map k v -> List (Tuple k v)
 toList Leaf = Nil
 toList (Two left k v right) = toList left <> Tuple k v : toList right
 toList (Three left k1 v1 mid k2 v2 right) = toList left <> Tuple k1 v1 : toList mid <> Tuple k2 v2 : toList right
+
+-- | Convert a map to a list of key/value pairs where the keys are in ascending order
+toAscList :: forall k v. Map k v -> List (Tuple k v)
+toAscList = toList
 
 -- | Convert a map to an unfoldable structure of key/value pairs
 toUnfoldable :: forall f k v. Unfoldable f => Map k v -> f (Tuple k v)

--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -54,13 +54,13 @@ data Map k v
   | Three (Map k v) k v (Map k v) k v (Map k v)
 
 instance eqMap :: (Eq k, Eq v) => Eq (Map k v) where
-  eq m1 m2 = toList m1 == toList m2
+  eq m1 m2 = toAscList m1 == toAscList m2
 
 instance ordMap :: (Ord k, Ord v) => Ord (Map k v) where
-  compare m1 m2 = compare (toList m1) (toList m2)
+  compare m1 m2 = compare (toAscList m1) (toAscList m2)
 
 instance showMap :: (Show k, Show v) => Show (Map k v) where
-  show m = "(fromList " <> show (toList m) <> ")"
+  show m = "(fromList " <> show (toAscList m) <> ")"
 
 instance semigroupMap :: Ord k => Semigroup (Map k v) where
   append = union

--- a/test/Test/Data/Map.purs
+++ b/test/Test/Data/Map.purs
@@ -218,6 +218,12 @@ mapTests = do
             groupBy ((==) `on` fst) <<< sortBy (compare `on` fst) in
     M.fromFoldableWith (<>) arr === f (arr :: List (Tuple String String))
 
+  log "toAscList is sorted version of toList"
+  quickCheck $ \(TestMap m) ->
+    let list = M.toList (m :: M.Map SmallKey Int)
+        ascList = M.toAscList m
+    in ascList === sortBy (compare `on` fst) list
+
   log "Lookup from union"
   quickCheck $ \(TestMap m1) (TestMap m2) k ->
     M.lookup (smallKey k) (M.union m1 m2) == (case M.lookup k m1 of

--- a/test/Test/Data/Map.purs
+++ b/test/Test/Data/Map.purs
@@ -166,7 +166,7 @@ mapTests = do
     in M.lookup k tree == Just v <?> ("instrs:\n  " <> show instrs <> "\nk:\n  " <> show k <> "\nv:\n  " <> show v)
 
   log "Singleton to list"
-  quickCheck $ \k v -> M.toList (M.singleton k v :: M.Map SmallKey Int) == singleton (Tuple k v)
+  quickCheck $ \k v -> M.toUnfoldable (M.singleton k v :: M.Map SmallKey Int) == singleton (Tuple k v)
 
   log "fromFoldable [] = empty"
   quickCheck (M.fromFoldable [] == (M.empty :: M.Map Unit Unit)
@@ -190,16 +190,11 @@ mapTests = do
     quickCheck (M.lookup 1 nums == Just 2  <?> "invalid lookup - 1")
     quickCheck (M.lookup 2 nums == Nothing <?> "invalid lookup - 2")
 
-  log "sort . toList . fromFoldable = sort (on lists without key-duplicates)"
+  log "sort . toUnfoldable . fromFoldable = sort (on lists without key-duplicates)"
   quickCheck $ \(list :: List (Tuple SmallKey Int)) ->
     let nubbedList = nubBy ((==) `on` fst) list
-        f x = M.toList (M.fromFoldable x)
+        f x = M.toUnfoldable (M.fromFoldable x)
     in sort (f nubbedList) == sort nubbedList <?> show nubbedList
-
-  log "fromFoldable . toList = id"
-  quickCheck $ \(TestMap (m :: M.Map SmallKey Int)) ->
-    let f m' = M.fromFoldable (M.toList m')
-    in f m == m <?> show m
 
   log "fromFoldable . toUnfoldable = id"
   quickCheck $ \(TestMap (m :: M.Map SmallKey Int)) ->
@@ -317,5 +312,6 @@ mapTests = do
   quickCheck $ \(TestMap m :: TestMap String Int) -> let
     f k v = k <> show v
     resultViaMapWithKey = m # M.mapWithKey f
-    resultViaLists = m # M.toList # map (\(Tuple k v) → Tuple k (f k v)) # M.fromFoldable
+    toList = M.toUnfoldable :: forall k v. M.Map k v -> List (Tuple k v)
+    resultViaLists = m # toList # map (\(Tuple k v) → Tuple k (f k v)) # M.fromFoldable
     in resultViaMapWithKey === resultViaLists


### PR DESCRIPTION
The current version of `toList` has the nice undocumented property that it returns key/value pairs in ascending order. Per recent changes to `toUnfoldable` (#76), I can imagine this implementation being changed in the future, breaking this property. So here's a synonym which assures the user that they will get their key/value pairs in ascending order, together with a test.

In case you were curious: I adapted @sammthomson's benchmark from #76 to a couple different ways to compute sorted & unsorted collections from maps:

![map tounfoldable 1](https://cloud.githubusercontent.com/assets/643799/22097159/72a92506-ddd4-11e6-9b95-d86613dae7b4.png)

This suggests that `toList` is a faster way to get a sorted collection than sorting the output of `toUnfoldable` (with list or array output), but it is a slower way to get an unsorted list than running `toUnfoldable` with list output.