### PR TITLE
size in log(n)

### DIFF
--- a/bench/Bench/Data/Map.purs
+++ b/bench/Bench/Data/Map.purs
@@ -1,0 +1,33 @@
+module Bench.Data.Map where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Performance.Minibench (bench, benchWith)
+
+import Data.Tuple (Tuple(..))
+import Data.List as L
+import Data.Map as M
+
+benchMap :: Eff (console :: CONSOLE) Unit
+benchMap = benchSize
+  where
+  benchSize = do
+    let nats = L.range 0 999999
+        natPairs = (flip Tuple) unit <$> nats
+        singletonMap = M.singleton 0 unit
+        smallMap = M.fromFoldable $ L.take 100 natPairs
+        midMap = M.fromFoldable $ L.take 10000 natPairs
+        bigMap = M.fromFoldable $ natPairs
+
+    log "size: singleton map"
+    bench \_ -> M.size singletonMap
+
+    log $ "size: small map (" <> show (M.size smallMap) <> ")"
+    bench \_ -> M.size smallMap
+
+    log $ "size: midsize map (" <> show (M.size midMap) <> ")"
+    benchWith 100 \_ -> M.size midMap
+
+    log $ "size: big map (" <> show (M.size bigMap) <> ")"
+    benchWith 10  \_ -> M.size bigMap

--- a/bench/Bench/Main.purs
+++ b/bench/Bench/Main.purs
@@ -1,0 +1,10 @@
+module Bench.Main where
+
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE)
+import Data.Unit (Unit)
+
+import Bench.Data.Map (benchMap)
+
+main :: Eff (console :: CONSOLE) Unit
+main = benchMap

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "purescript-st": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-quickcheck": "^4.0.0"
+    "purescript-quickcheck": "^4.0.0",
+    "purescript-minibench": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
     "build": "eslint src && pulp build -- --censor-lib --strict",
-    "test": "pulp test"
+    "test": "pulp test",
+
+    "bench:build": "purs compile 'bench/**/*.purs' 'src/**/*.purs' 'bower_components/*/src/**/*.purs'",
+    "bench:run": "node -e 'require(\"./output/Bench.Main/index.js\").main()'",
+    "bench": "npm run bench:build && npm run bench:run"
   },
   "devDependencies": {
     "eslint": "^3.17.1",

--- a/src/Data/Map.purs
+++ b/src/Data/Map.purs
@@ -473,7 +473,9 @@ isSubmap m1 m2 = LL.all f $ (toUnfoldable m1 :: LL.List (Tuple k v))
 
 -- | Calculate the number of key/value pairs in a map
 size :: forall k v. Map k v -> Int
-size = length <<< values
+size Leaf = 0
+size (Two m1 _ _ m2) = 1 + size m1 + size m2
+size (Three m1 _ _ m2 _ _ m3) = 2 + size m1 + size m2 + size m3
 
 -- | Apply a function of two arguments to each key/value pair, producing a new map
 mapWithKey :: forall k v v'. (k -> v -> v') -> Map k v -> Map k v'


### PR DESCRIPTION
addresses #100
adds benchmarks, addressing #101

Before:

```
size: singleton map
mean   = 7.85 μs
stddev = 62.54 μs
min    = 1.91 μs
max    = 1.60 ms
size: small map (100)
mean   = 303.09 μs
stddev = 482.41 μs
min    = 205.12 μs
max    = 3.85 ms
size: midsize map (10000)
mean   = 40.37 ms
stddev = 1.42 ms
min    = 36.60 ms
max    = 46.82 ms
size: big map (1000000)
mean   = 5.79 s
stddev = 60.76 ms
min    = 5.67 s
max    = 5.89 s
```

After:

```
size: singleton map
mean   = 3.00 μs
stddev = 38.96 μs
min    = 326.00 ns
max    = 1.16 ms
size: small map (100)
mean   = 10.16 μs
stddev = 7.21 μs
min    = 8.35 μs
max    = 175.09 μs
size: midsize map (10000)
mean   = 901.31 μs
stddev = 198.26 μs
min    = 822.48 μs
max    = 1.88 ms
size: big map (1000000)
mean   = 96.70 ms
stddev = 2.00 ms
min    = 92.99 ms
max    = 99.69 ms
```