### PR TITLE
make toUnfoldable ordered

### DIFF
--- a/test/Test/Data/Map.purs
+++ b/test/Test/Data/Map.purs
@@ -175,11 +175,10 @@ mapTests = do
             groupBy ((==) `on` fst) <<< sortBy (compare `on` fst) in
     M.fromFoldableWith (<>) arr === f (arr :: List (Tuple String String))
 
-  log "toAscUnfoldable is sorted version of toUnfoldable"
+  log "toUnfoldable is sorted"
   quickCheck $ \(TestMap m) ->
     let list = M.toUnfoldable (m :: M.Map SmallKey Int)
-        ascList = M.toAscUnfoldable m
-    in ascList === sortBy (compare `on` fst) list
+    in  list === sortBy (compare `on` fst) list
 
   log "Lookup from union"
   quickCheck $ \(TestMap m1) (TestMap m2) k ->
@@ -283,7 +282,7 @@ mapTests = do
 
   log "filterWithKey keeps those keys for which predicate is true"
   quickCheck $ \(TestMap s :: TestMap String Int) p ->
-                 A.all (uncurry p) (M.toAscUnfoldable (M.filterWithKey p s) :: Array (Tuple String Int))
+                 A.all (uncurry p) (M.toUnfoldable (M.filterWithKey p s) :: Array (Tuple String Int))
 
   log "filterKeys gives submap"
   quickCheck $ \(TestMap s :: TestMap String Int) p ->


### PR DESCRIPTION
addresses https://github.com/purescript/purescript-maps/issues/135

toAscUnfoldable becomes a deprecated equivalent to toUnfoldable. We introduce `unsafeToUnfoldable` for the unsorted traversal.